### PR TITLE
Move to setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ url = "https://github.com/sharppy/SHARPpy"
 packages = find_packages()
 package_data = {"": ["*.md", "*.txt", "*.png"],}
 include_package_data = True
-classifiers = ["Development Status :: 2 - Pre-Alpha"]
+classifiers = ["Development Status :: 4 - Beta"]
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -1,28 +1,47 @@
-from distutils.core import setup
 import os, sys
+from setuptools import setup, find_packages
+
 
 pkgname = "SHARPpy"
+
+
+### GET VERSION INFORMATION ###
 setup_path = os.path.split(os.path.abspath(__file__))[0]
 sys.path.append(os.path.join(setup_path, pkgname.lower()))
 import version
 version.write_git_version()
-ver = version.get_version()
+ver = version.get_version().split("+")[0]
 sys.path.pop()
 
 
+### ACTUAL SETUP VALUES ###
+name = pkgname
+version = ver
+author = "Patrick Marsh, Kelton Halbert, and Greg Blumberg"
+author_email = "patrick.marsh@noaa.gov, keltonhalbert@ou.edu, wblumberg@ou.edu"
+description = "Sounding/Hodograph Analysis and Research Program for Python"
+long_description = ""
+license = "BSD"
+keywords = "meteorology soundings analysis"
+url = "https://github.com/sharppy/SHARPpy"
+packages = find_packages()
+package_data = {"": ["*.md", "*.txt", "*.png"],}
+include_package_data = True
+classifiers = ["Development Status :: 2 - Pre-Alpha"]
+
+
 setup(
-    name = pkgname,
-    version = ver,
-    author = "Patrick Marsh, John Hart, Kelton Halbert, and Greg Blumberg",
-    author_email = "patrick.marsh@noaa.gov, john.hart@noaa.gov, keltonhalbert@ou.edu, wblumberg@ou.edu",
-    description = ("Sounding/Hodograph Analysis and Research Program " \
-        "for Python"),
-    license = "BSD",
-    keywords = "meteorology soundings analysis",
-    url = "",
-    packages=['sharppy', 'sharppy.io', 'sharppy.sharptab', 'sharppy.viz', 'sharppy.databases'],
-    package_data={'': ['*.md', '*.txt', '*.png']},
-    include_package_data=True,
-    long_description="",
-    classifiers=["Development Status :: 2 - Pre-Alpha"],
+    name = name,
+    version = version,
+    author = author,
+    author_email = author_email,
+    description = description,
+    long_description = long_description,
+    license = license,
+    keywords = keywords,
+    url = url,
+    packages = packages,
+    package_data = package_data,
+    include_package_data = include_package_data,
+    classifiers = classifiers
 )


### PR DESCRIPTION
Heads up @keltonhalbert, @wblumberg 

This pull requests does a couple of things.

1. Converts the setup script from distutils to setuptools. This allows for better integration with pip. (More importantly, allows users to remove SHARPpy by using pip.

2. Changes the Development Status from Pre-Alpha to Beta

3. Adds additional stuff to the version scripts: 
  + The branch, date, and git hash are included in the version string.
  + This information is stripped from the version information that is appended to the module name (this is for pip integration). However, it remains if one does ```import sharppy; sharppy.__version__```

Lastly, although not tackled in this pull-request, at some point someone should consider updating the version number from 0.1.0 to something more realistic. I would suggest utilizing the major.minor.bugfix nomenclature, where everything is minor updates unless a major new feature is added (one that typically may break how the module is currently used).

In keeping with my beliefs, I won't merge my own pull-request into master. So can people please check this branch and if it works for others, merge this into master.