### PR TITLE
StrictQC Keyword Argument and Boundary Relative Vector Fixes

### DIFF
--- a/sharppy/sharptab/profile.py
+++ b/sharppy/sharptab/profile.py
@@ -205,6 +205,8 @@ class BasicProfile(Profile):
         '''
         super(BasicProfile, self).__init__(**kwargs)
 
+        strictQC = kwargs.get('strictQC', False)
+
         assert len(self.pres) == len(self.hght) == len(self.tmpc) == len(self.dwpc),\
                 "Length of pres, hght, tmpc, or dwpc arrays passed to constructor are not the same."
 
@@ -251,15 +253,15 @@ class BasicProfile(Profile):
 
         #if not qc_tools.isPRESValid(self.pres):
         ##    qc_tools.raiseError("Incorrect order of pressure array (or repeat values) or pressure array is of length <= 1.", ValueError)
-        if not qc_tools.isHGHTValid(self.hght):
+        if not qc_tools.isHGHTValid(self.hght) and strictQC:
             qc_tools.raiseError("Incorrect order of height (or repeat values) array or height array is of length <= 1.", ValueError)
         if not qc_tools.isTMPCValid(self.tmpc):
             qc_tools.raiseError("Invalid temperature array. Array contains a value < 273.15 Celsius.", ValueError)
         if not qc_tools.isDWPCValid(self.dwpc):
             qc_tools.raiseError("Invalid dewpoint array. Array contains a value < 273.15 Celsius.", ValueError)
-        if not qc_tools.isWSPDValid(self.wspd):
+        if not qc_tools.isWSPDValid(self.wspd) and strictQC:
             qc_tools.raiseError("Invalid wind speed array. Array contains a value < 0 knots.", ValueError)
-        if not qc_tools.isWDIRValid(self.wdir):
+        if not qc_tools.isWDIRValid(self.wdir) and strictQC:
             qc_tools.raiseError("Invalid wind direction array. Array contains a value < 0 degrees or value >= 360 degrees.", ValueError)     
 
 

--- a/sharppy/sharptab/profile.py
+++ b/sharppy/sharptab/profile.py
@@ -205,7 +205,7 @@ class BasicProfile(Profile):
         '''
         super(BasicProfile, self).__init__(**kwargs)
 
-        strictQC = kwargs.get('strictQC', False)
+        strictQC = kwargs.get('strictQC', True)
 
         assert len(self.pres) == len(self.hght) == len(self.tmpc) == len(self.dwpc),\
                 "Length of pres, hght, tmpc, or dwpc arrays passed to constructor are not the same."

--- a/sharppy/viz/hodo.py
+++ b/sharppy/viz/hodo.py
@@ -607,12 +607,13 @@ class plotHodo(backgroundHodo):
                 width = 150
                 qp = self.setBlackPen(qp)
                 rect = QtCore.QRectF(3, self.bry-35, width, hght)
-                qp.drawRect(rect) 
+                qp.drawRect(rect)
                 shear_color = QtGui.QColor("#0099CC")
                 pen = QtGui.QPen(shear_color, penwidth)
                 qp.setFont(self.critical_font)
                 qp.setPen(pen)
-                x2, y2 = self.uv_to_pix(self.prof.sfc_6km_shear[0], self.prof.sfc_6km_shear[1])
+                to_add = self.pix_to_uv(e.x(), e.y())
+                x2, y2 = self.uv_to_pix(self.prof.sfc_6km_shear[0] + to_add[0], self.prof.sfc_6km_shear[1]+ to_add[1])
                 qp.drawLine(e.x(), e.y(), x2, y2)
                 dir, spd = tab.utils.comp2vec(self.prof.sfc_6km_shear[0], self.prof.sfc_6km_shear[1])
                 qp.drawText(rect, QtCore.Qt.TextDontClip | QtCore.Qt.AlignLeft, "0 - 6 km Shear: " + tab.utils.INT2STR(dir) + '/' + tab.utils.INT2STR(spd) + ' kts')
@@ -621,11 +622,11 @@ class plotHodo(backgroundHodo):
                 width = 200
                 qp = self.setBlackPen(qp)
                 rect = QtCore.QRectF(3, self.bry-20, width, hght)
-                qp.drawRect(rect) 
+                qp.drawRect(rect)
                 srw_color = QtGui.QColor("#FF00FF")
                 pen = QtGui.QPen(srw_color, penwidth)
                 qp.setPen(pen)
-                x2, y2 = self.uv_to_pix(self.prof.srw_9_11km[0], self.prof.srw_9_11km[1])
+                x2, y2 = self.uv_to_pix(self.prof.srw_9_11km[0] + to_add[0], self.prof.srw_9_11km[1] + to_add[1])
                 qp.drawLine(e.x(), e.y(), x2, y2)
                 dir, spd = tab.utils.comp2vec(self.prof.srw_9_11km[0], self.prof.srw_9_11km[1])
                 if spd >= 70:
@@ -635,7 +636,6 @@ class plotHodo(backgroundHodo):
                 else:
                     supercell_type = "HP"
                 qp.drawText(rect, QtCore.Qt.TextDontClip | QtCore.Qt.AlignLeft, "9 - 11 km SR-Wind: " + tab.utils.INT2STR(dir) + '/' + tab.utils.INT2STR(spd) + ' kts - (' + supercell_type + ')')
-
                 # Removing this function until @wblumberg can finish fixing this function.
                 """
                 # Draw the descrete vs mixed/linear mode output only if there is an LCL-EL layer.

--- a/sharppy/viz/hodo.py
+++ b/sharppy/viz/hodo.py
@@ -635,7 +635,9 @@ class plotHodo(backgroundHodo):
                 else:
                     supercell_type = "HP"
                 qp.drawText(rect, QtCore.Qt.TextDontClip | QtCore.Qt.AlignLeft, "9 - 11 km SR-Wind: " + tab.utils.INT2STR(dir) + '/' + tab.utils.INT2STR(spd) + ' kts - (' + supercell_type + ')')
-                
+
+                # Removing this function until @wblumberg can finish fixing this function.
+                """
                 # Draw the descrete vs mixed/linear mode output only if there is an LCL-EL layer.
                 norm_Shear, mode_Shear, norm_Wind, norm_Mode = self.calculateStormMode()
  
@@ -672,7 +674,7 @@ class plotHodo(backgroundHodo):
                     pen = QtGui.QPen(color, penwidth)
                     qp.setPen(pen)
                     qp.drawText(rect, QtCore.Qt.TextDontClip | QtCore.Qt.AlignLeft, "From Bndy 0-6 km Shr Diff (" + tab.utils.INT2STR(norm_Shear) + " m/s): " + mode_Shear)
-
+                """
                 qp.end()
 
                 self.update()


### PR DESCRIPTION
This pull request contains a few fixes and adjustments in preparation for the upcoming release:

1.) A strictQC argument has now been added as an optional keyword argument of the Profile object.  The default value is True and is set to this until all developers can agree on a consensus of how to handle some of the odd observed profiles that the SHARPpy GUI is reading in.  Setting this to False will cause the Profile object constructor to skip over some of the more strict QC checks on the data being passed to the constructor.  This setup is a potential fix to the issues associated with the QC when reading in different data types through the GUI and the script.

2.) When plotting the boundary on the hodograph, the 0-6 km shear and 9-11 km storm relative wind vectors get transposed properly now.  This fix was motivated after the boundary motion function was shown in NSHARP.  

3.) I have removed (for the time being) the storm mode estimation function that is drawn when you plot a boundary motion on the hodograph.  This is due to a couple of odd errors that I noticed when using this function.   This functionality will be reinstated once I get time to properly fix it.