### PR TITLE
BUG: Continue through full_gui if xml load doesn't work.

### DIFF
--- a/datasources/data_source.py
+++ b/datasources/data_source.py
@@ -39,7 +39,11 @@ def loadDataSources(ds_dir=HOME_DIR):
         root = ET.parse(ds_file).getroot()
         for src in root:
             name = src.get('name')
-            ds[name] = DataSource(src)
+            try:
+                ds[name] = DataSource(src)
+            except:
+                print('Unable to process %s file'%os.path.basename(ds_file))
+
     return ds
 
 def _pingURL(hostname, timeout=1):
@@ -47,7 +51,7 @@ def _pingURL(hostname, timeout=1):
         urllib2.urlopen(hostname, timeout=timeout)
     except urllib2.URLError:
         return False
-        
+
     return True
 
 def pingURLs(ds_dict):
@@ -134,7 +138,7 @@ class Outlet(object):
 
         daily_cycles = self.getCycles()
         time_counter = daily_cycles.index(start.hour)
-        archive_len = self.getArchiveLen() 
+        archive_len = self.getArchiveLen()
 
         cycles = []
         cur_time = start
@@ -208,7 +212,7 @@ class Outlet(object):
 
     def hasProfile(self, point, cycle):
         times = self.getAvailableTimes()
-        has_prof = cycle in times 
+        has_prof = cycle in times
 
         if has_prof:
             stns = self.getAvailableAtTime(dt=cycle)
@@ -316,7 +320,7 @@ class DataSource(object):
         outlet = self._getOutletWithProfile(stn, cycle_dt, outlet)
         url_base = self._outlets[outlet].getURL()
 
-        fmt = { 
+        fmt = {
             'srcid':urllib.quote(stn['srcid']),
             'cycle':"%02d" % cycle_dt.hour,
             'date':cycle_dt.strftime("%y%m%d")


### PR DESCRIPTION
Problem loading discussed in Issue #86 continued. Using the method:
```
python runsharp/full_gui.py
```

Nothing fancy, this quick fix allows the GUI to skip xml files that do not load properly (I found that *mpas.xml* and *pecan.xml* did not load). It will work as long as one instance is loaded into the **ds** dictionary, but I'm not sure the error testing is solid enough if none load.