### PR TITLE
SPCWindow rmProfileCollection Method Fix

### DIFF
--- a/sharppy/viz/SPCWindow.py
+++ b/sharppy/viz/SPCWindow.py
@@ -288,6 +288,7 @@ class SPCWidget(QWidget):
             pc_idx = self.prof_ids.index(prof_id)
         except ValueError:
             print "Hmmm, that profile doesn't exist to be removed ..."
+            return
 
         prof_col = self.prof_collections.pop(pc_idx)
         self.prof_ids.pop(pc_idx)


### PR DESCRIPTION
Added return statement to except statement in rmProfileCollection...this is consistent with the same logic in the setProfileCollection method above it. Without this return statement when a profile does not exist to be removed it continues on after the except and triggers errors in the following code since pc_idx variable is never set.