### PR TITLE
Fixed parcel lifting function 

### DIFF
--- a/sharppy/sharptab/thermo.py
+++ b/sharppy/sharptab/thermo.py
@@ -265,7 +265,7 @@ def satlift(p, thetam):
         if np.fabs(p - 1000.) - 0.001 <= 0: 
             return thetam
         eor = 999
-        while np.fabs(eor) - 0.1 > 0:
+        while np.fabs(eor) - 0.01 > 0:
             if eor == 999:                  # First Pass
                 pwrp = np.power((p / 1000.),ROCP)
                 t1 = (thetam + ZEROCNK) * pwrp - ZEROCNK


### PR DESCRIPTION
This pull request fixes an issue in SHARPpy that occurs when very high resolution sondes are put into the program.  This problem is with the Wobus function/wetlift() logic where the iterative portion of the algorithm converges too early when using high resolution soundings.  This problem causes odd looking parcel traces to appear in the program and an overestimation of instability in the atmosphere.  The problem arises because the original SHARP code was never (or rarely) tested using high-res sondes.

Future updates may modify the threshold for convergence, but for now this threshold seems to resolve the problem.  Other updates may abandon the Wobus function method for the Robert-Davies Jones (2008) method (which is currently in the testing phase).