### PR TITLE
Updated SPC decoder to handle SPC Mesoanalysis text files

### DIFF
--- a/sharppy/sharptab/profile.py
+++ b/sharppy/sharptab/profile.py
@@ -195,7 +195,7 @@ class Profile(object):
         #print(now, self.date)
         user = getpass.getuser()
         snd_file.write("%TITLE%\n")
-        #snd_file.write("%s   %s\n Saved by user: %s on %s UTC\n" % (snd_loc, self.date.strftime("%y%m%d/%H%M"), user, now.strftime('%Y%m%d/%H%M')))
+        snd_file.write("%s   %s\n Saved by user: %s on %s UTC\n" % (snd_loc, self.date.strftime("%y%m%d/%H%M"), user, now.strftime('%Y%m%d/%H%M')))
         snd_file.write("   LEVEL       HGHT       TEMP       DWPT       WDIR       WSPD\n")
         snd_file.write("-------------------------------------------------------------------\n")
         snd_file.write("%RAW%\n")


### PR DESCRIPTION
## Updated SPC decoder to handle SPC Mesoanalysis text files

### What Changed
SPC Mesoanalysis text files from their archives often include the Omega field, and have a slightly diferent metadata header for the date. This would cause the SPC Decoder to not recognize these files (I've attached one for reference). 

[20130531_0025_EF1_36.12_-95.23_93_455311 (copy).txt](https://github.com/sharppy/SHARPpy/files/2954221/20130531_0025_EF1_36.12_-95.23_93_455311.copy.txt)

This change includes some try/except blocks to test whether this is an observed SPC file, or one from the Mesoanalysis and handle the appropriate situation. As far as I can tell, this doesn't break functionality for the observed sounding text as I've been able to read the old format just fine. 

Additionally, in sharptab/profiles.py, the line that specifies the location and date of the file saved was commented out. This prevented users from being able to open a file saved by SHARPpy itself, which I doubt was intended. I've uncommented that line and left it as-is. 

### Why It Changed
The reason for these changes is that we're using SHARPpy to look at the SPC Mesoanalysis files provided to us to look into initializing CM1 simulations. Sometimes that requires modifying the sounding in some way, which the GUI is very useful for. We can then save out the modified sounding to a text file, and send it to our preprocessor that converts it to the format desired by CM1 and interpolates it to 100 meter height intervals. 

In the near future, I will also be making a pull request for a new decoder that reads in the CM1 sounding format so that the resulting output can be checked. I haven't written it yet though because this format only contains the surface pressure, which means programming in some hypsometric equation stuff I really don't feel like doing right now. 