### PR TITLE
Fix data point skipping on hodo

### DIFF
--- a/sharppy/viz/hodo.py
+++ b/sharppy/viz/hodo.py
@@ -1228,7 +1228,7 @@ class plotHodo(backgroundHodo):
 
             path = QPainterPath()
             path.moveTo(seg_x[idx], seg_y[idx])
-            for z_idx in xrange(seg_idxs[idx] + 1, seg_idxs[idx + 1]):
+            for z_idx in xrange(seg_idxs[idx], seg_idxs[idx + 1]):
                 path.lineTo(xx[z_idx], yy[z_idx])
             path.lineTo(seg_x[idx + 1], seg_y[idx + 1])
 


### PR DESCRIPTION
This seems to be a subtle off-by-one index error when drawing each colored 3-km segment of the hodo. The first data point after a segment cutoff is skipped when connecting u,v points. If z = [..., 2900, 3100, 3300, ...], then the u,v point at 3100 m AGL is skipped, since it's the first index after the 3-km segment cutoff. Only becomes noticeable with vertically sparse data.