### PR TITLE
Fix calculation of CAP

### DIFF
--- a/sharppy/sharptab/params.py
+++ b/sharppy/sharptab/params.py
@@ -1930,7 +1930,7 @@ def parcelx(prof, pbot=None, ptop=None, dp=-1, **kwargs):
             li_maxpres = pe2
         
         # Check for Max Cap Strength
-        mcap = te2 - mli
+        mcap = -mli
         if mcap > cap_strength:
             cap_strength = mcap
             cap_strengthpres = pe2


### PR DESCRIPTION
### Referenced issue
#216 

### Changes
Changes calculation of CAP inside the `parcelx` function. It is now the difference between the virtual temperature of the parcel and the profile.