### PR TITLE
Bug(?) in SRH calculation?

### DIFF
--- a/utils/async.py
+++ b/utils/async.py
@@ -5,6 +5,7 @@ import Queue
 import hashlib
 from datetime import datetime
 import traceback
+import sys
 
 class AsyncThreads(QObject):
     """
@@ -99,6 +100,9 @@ class AsyncThreads(QObject):
         if self.running < self.max_threads:
             # Might not be the case if we just started a high-priority thread
             self.startNext()
+
+        sys.stdout.write(" \x1b[D") # This fixes a weird bug on Debian. I think the threads die
+        sys.stdout.flush()          # prematurely unless you print something here ... ???????
 
     def _genThreadId(self):
         time_stamp = datetime.utcnow().isoformat()


### PR DESCRIPTION
After calculating with SHARPpy the **storm relative helicity(SRH) for 0-3 km**, for the following sounding profile, I got some very low values compared to other similar programs that can do the calculations.

For example i got with SHARPpy an SRH0-3 of **195** m²/s²
While i got with RAOB an SRH0-3 of **718** m²/s²
And using the page of [http://contourmap.internet-box.ch/hpbo/sounding_create.aspx](url) (for 11 October 2015 for 16716 station) i got an SRH0-3 of **678** m²/s²

Same for SRH0-1 km where i got:
With SHARPpy an SRH0-3 of **141** m²/s²
And with RAOB an SRH0-3 of **530** m²/s²

Is there a bug in SHARPpy's code for SRH calculation? 
Or the converted format I've created from the original sounding in order to use in SHARPpy is faulty?

Furthermore comparing the 2 hodographs from RAOB and SHARPpy(see pictures in the end) tells me SHARPpy might not take the first 6 km of the surface the same way as RAOB and other programs do. 



The **sounding** is: 
[http://weather.uwyo.edu/cgi-bin/sounding?region=europe&TYPE=TEXT%3ALIST&YEAR=2015&MONTH=10&FROM=1112&TO=1112&STNM=16716](url)


And the corresponding sounding format I used with SHARPpy is:
```
%TITLE%
16716 111015/0012

   LEVEL       HGHT       TEMP       DWPT       WDIR       WSPD
-------------------------------------------------------------------
%RAW%
1002.0,       15,       28.0,       20.0,       160,       4.6299999960000005
1000.0,       56,       27.2,       17.2,       160,       5.658888884
998.0,       74,       26.2,       16.2,       160,       6.6877777720000005
978.0,       250,       24.6,       15.9,       160,       15.947777764
942.0,       578,       21.5,       15.4,       170,       15.947777764
925.0,       737,       20.0,       15.2,       185,       19.034444428
921.0,       774,       19.6,       15.5,       187,       20.063333316
910.0,       878,       19.4,       14.4,       194,       22.121111092
905.0,       926,       20.8,       13.8,       197,       23.14999998
892.0,       1050,       20.1,       12.6,       205,       25.7222222
850.0,       1465,       17.6,       8.6,       210,       28.29444442
823.0,       1741,       16.4,       6.4,       214,       30.86666664
791.0,       2072,       13.9,       4.9,       220,       33.953333304
700.0,       3094,       6.2,       0.2,       220,       30.86666664
578.0,       4633,       -5.7,       -8.4,       223,       29.837777752
575.0,       4673,       -5.3,       -15.3,       223,       29.837777752
546.0,       5078,       -7.5,       -29.5,       224,       29.323333308
525.0,       5383,       -8.7,       -25.7,       224,       29.323333308
520.0,       5457,       -9.5,       -17.5,       224,       28.808888864
504.0,       5699,       -9.9,       -31.9,       225,       28.808888864
500.0,       5760,       -10.5,       -31.5,       225,       28.808888864
477.0,       6120,       -12.9,       -24.9,       225,       27.265555532
467.0,       6282,       -13.8,       -33.1,       225,       26.236666644
466.0,       6298,       -13.9,       -33.9,       225,       26.236666644
451.0,       6545,       -16.1,       -26.1,       228,       25.207777756
425.0,       6990,       -17.9,       -34.9,       234,       23.14999998
405.0,       7348,       -20.7,       -44.7,       239,       21.606666648
400.0,       7440,       -21.7,       -45.7,       240,       21.092222204
353.0,       8344,       -30.1,       -30.9,       245,       21.606666648
351.0,       8384,       -30.4,       -32.2,       245,       21.606666648
339.0,       8630,       -32.3,       -40.3,       242,       21.092222204
336.0,       8693,       -32.1,       -56.1,       241,       21.092222204
327.0,       8883,       -33.7,       -59.7,       238,       20.57777776
316.0,       9121,       -35.7,       -58.1,       235,       20.063333316
312.0,       9210,       -36.5,       -57.5,       235,       20.063333316
308.0,       9299,       -37.1,       -43.1,       235,       20.063333316
300.0,       9480,       -38.9,       -43.9,       235,       20.063333316
268.0,       10241,       -45.7,       -50.7,       235,       23.14999998
250.0,       10700,       -48.5,       -54.5,       235,       25.207777756
235.0,       11102,       -51.2,       -57.6,       250,       27.779999976
213.0,       11740,       -55.5,       -62.5,       259,       36.01111108
212.0,       11770,       -55.3,       -67.3,       260,       36.525555524
200.0,       12140,       -57.9,       -65.9,       265,       41.15555552
191.0,       12429,       -59.5,       -67.5,       269,       44.242222184
190.0,       12461,       -59.2,       -67.2,       270,       44.756666628
184.0,       12663,       -57.7,       -65.7,       268,       38.5833333
167.0,       13260,       -62.4,       -71.0,       260,       19.034444428
157.0,       13641,       -65.4,       -74.3,       270,       17.491111096
153.0,       13800,       -66.7,       -75.7,       265,       20.57777776
150.0,       13920,       -64.1,       -74.1,       260,       24.693333312
147.0,       14045,       -62.7,       -77.6,       260,       26.751111088000002
141.0,       14303,       -59.9,       -84.9,       263,       23.664444424
130.0,       14808,       -62.7,       -92.7,       269,       18.00555554
120.0,       15306,       -60.1,       -90.9,       275,       12.346666656
118.0,       15410,       -59.5,       -90.5,       265,       11.317777768
112.0,       15735,       -60.5,       -91.1,       235,       8.745555548
107.0,       16019,       -61.3,       -91.7,       240,       11.317777768
103.0,       16256,       -62.0,       -92.1,       260,       13.889999988
100.0,       16440,       -62.5,       -92.5,       255,       15.947777764
92.0,       16952,       -64.2,       -94.2,       260,       17.491111096
91.3,       16999,       -64.3,       -94.3,       263,       18.519999984000002
89.0,       17157,       -63.7,       -93.8,       275,       21.606666648
81.0,       17740,       -61.3,       -91.9,       280,       15.947777764
78.0,       17973,       -60.4,       -91.1,       300,       14.918888876
75.0,       18216,       -59.4,       -90.3,       285,       17.491111096
74.8,       18233,       -59.3,       -90.3,       285,       16.976666652
73.0,       18385,       -59.7,       -90.7,       285,       12.346666656
70.0,       18650,       -55.5,       -87.5,       285,       4.6299999960000005
69.3,       18714,       -54.9,       -86.9,       261,       3.601111108
69.0,       18742,       -55.1,       -87.1,       250,       3.086666664
66.0,       19023,       -57.4,       -88.9,       225,       6.6877777720000005
64.0,       19218,       -58.9,       -90.1,       220,       10.28888888
62.8,       19337,       -59.9,       -90.9,       226,       12.8611111
62.0,       19418,       -59.4,       -90.5,       230,       14.918888876
58.0,       19839,       -57.1,       -88.8,       275,       9.259999992000001
56.0,       20061,       -55.8,       -87.8,       245,       8.745555548
55.8,       20084,       -55.7,       -87.7,       246,       8.745555548
51.0,       20655,       -57.7,       -89.7,       280,       14.918888876
50.0,       20780,       -56.5,       -88.5,       290,       14.404444432
49.4,       20857,       -55.3,       -87.3,       302,       12.8611111
49.0,       20909,       -55.5,       -87.5,       310,       11.832222212
47.4,       21120,       -56.3,       -88.3,       310,       8.745555548
%END%

```


The pictures of RAOB and SHARPpy program for the above sounding:
[https://i.postimg.cc/nF0WqzSB/RAOB-Case1.png](url)
[https://i.postimg.cc/mLbqcMjT/SHARPpy-case1.png](url)







