### PR TITLE
Fix preferences window problem

### DIFF
--- a/sharppy/viz/preferences.py
+++ b/sharppy/viz/preferences.py
@@ -402,10 +402,10 @@ class PrefDialog(QDialog):
             self.combo1.addItem(k)
             self.combo2.addItem(k) 
 
-        idx1 = np.where(np.asarray(list(self.variables.values())) == self._config['preferences', 'readout_tr'])[0]
-        idx2 = np.where(np.asarray(list(self.variables.values())) == self._config['preferences', 'readout_br'])[0]
-        self.combo1.setCurrentIndex(idx1)
-        self.combo2.setCurrentIndex(idx2)
+        idxs1 = np.where(np.asarray(list(self.variables.values())) == self._config['preferences', 'readout_tr'])[0]
+        idxs2 = np.where(np.asarray(list(self.variables.values())) == self._config['preferences', 'readout_br'])[0]
+        self.combo1.setCurrentIndex(idxs1[0])
+        self.combo2.setCurrentIndex(idxs2[0])
 
         return box
 


### PR DESCRIPTION
This PR fixes the problem when the _Preferences_ window fails to open while running the latest code from the master branch (Issue #224).

In the existing code, the _where()_ call is actually returning a tuple of arrays. When _idx1_ is set to the first element, it is actually being set to the first element of the tuple which is an array. This array is then passed to _setCurrentIndex()_ which is expecting an integer.

The code has been updated as follows:

- _idx1_ and _idx2_ have been renamed to _idxs1_ and _idxs2_ to reflect that they are actually a collection of indices and not a single index.
- The first element of _idxs1_ and _idxs2_ is accessed and then passed to _setCurrentIndex()_ since the first element contains the actual index.