### PR TITLE
Added environment flag necessary to run on macOS Monterey with PySide2

### DIFF
--- a/runsharp/full_gui.py
+++ b/runsharp/full_gui.py
@@ -1,5 +1,6 @@
 import os
 os.environ['QT_API'] = 'pyside2' # Force PySide2 to be used in QtPy
+os.environ['QT_MAC_WANTS_LAYER'] = '1' ## MacOS compatability
 from qtpy.QtGui import *
 from qtpy.QtCore import *
 from qtpy.QtWidgets import *


### PR DESCRIPTION
This fixes an issue where the GUI hangs and never loads the application. Found the solution [here](https://www.loekvandenouweland.com/content/pyside2-big-sur-does-not-show-window.htmll) and implemented it into the full_gui.py script. 