### PR TITLE
Modified non_parcel_bunkers_motion_experimental to use non pressure weighted mean wind

### DIFF
--- a/sharppy/sharptab/winds.py
+++ b/sharppy/sharptab/winds.py
@@ -225,7 +225,7 @@ def non_parcel_bunkers_motion_experimental(prof):
     mnu500m, mnv500m = mean_wind(prof, psfc, p500m)
     
     ## 5.5km-6.0km Mean Wind
-    mnu5500m_6000m, mnv5500m_6000m = mean_wind(prof, p5500m, p6000m)
+    mnu5500m_6000m, mnv5500m_6000m = mean_wind_npw(prof, p5500m, p6000m)
     
     # shear vector of the two mean winds
     shru = mnu5500m_6000m - mnu500m


### PR DESCRIPTION
Per issue #209, it appears as though non_parcel_bunkers_motion_experimental is the function most similar to the process described in Bunkers et al. 2000 in that it uses the shear vector from the 0-0.5km mean wind to the 5.5-6km mean wind. The issue is that it was using the 0-6km pressure weighted mean wind in the calculation rather than the non pressure weighted mean wind which is recommended in Bunkers et al. 2000 and reaffirmed in Bunkers et al. 2014. This change modifies the function to use the non-pressure weighted mean wind. If the intention was to use pressure weighted mean wind, it should probably be the 0-8km mean wind as this was found to minimize error in Bunkers et al. 2014. This change does not solve the broader problem brought up by #209, namely that the bunkers motion calculations in SHARPpy use the 0-6km shear vector rather than the shear vector from the 0-0.5km mean wind to the 5.5-6km mean wind, but I was reluctant to make any larger changes as I'm not sure if this is actually a bug or if there was a valid reason as to why the 0-6km shear is being used.