### PR TITLE
Added check to ensure QThreads are finished before destroying them

### DIFF
--- a/sutils/async.py
+++ b/sutils/async.py
@@ -98,6 +98,9 @@ class AsyncThreads(QObject):
 
         callback(ret_val)
 
+        while not self.threads[thread_id].isFinished():
+            pass
+
         del self.threads[thread_id]
         del self.callbacks[thread_id]
 

--- a/sutils/async_threads.py
+++ b/sutils/async_threads.py
@@ -96,6 +96,9 @@ class AsyncThreads(QObject):
 
         callback(ret_val)
 
+        while not self.threads[thread_id].isFinished():
+            pass
+
         del self.threads[thread_id]
         del self.callbacks[thread_id]
 


### PR DESCRIPTION
This is a fix for issue #244. In async_threads (and also async, although I couldn't find that being used anywhere) threads are destroyed in the finish slot of the AsyncThreads class. This slot is called when the finished signal is emitted by one of the threads at the end of their run function and leads to a race condition where the thread might not truly finish running before del is called on it. Adding a while loop checking the QThread isFinished function before destroying the thread ensures that the thread has actually finished running.

On a related note, QThread already has a finished signal that gets emitted when the thread actually finishes. Unfortunately, this signal doesn't include any information on what thread finished so it can't be used to perform the cleanup needed in AsyncThreads. In any case, it might be a good idea to rename the finished signal in AsyncThread to something like completed to avoid any confusion with the QThread finished signal.