### PR TITLE
Fixed error in LHP

### DIFF
--- a/sharppy/sharptab/params.py
+++ b/sharppy/sharptab/params.py
@@ -452,9 +452,6 @@ def lhp(prof):
                  ((3200 - thk_hgz)/500.) +\
                  ((lr75 - 6.5)/2.))
 
-        if term_a < 0:
-            term_a = 0
-
         p_1km, p_3km, p_6km = interp.pres(prof, interp.to_msl(prof, [1000, 3000, 6000]))
         shear_el = utils.KTS2MS(utils.mag(*winds.wind_shear(prof, pbot=prof.pres[prof.sfc], ptop=prof.mupcl.elpres)))
         grw_el_dir = interp.vec(prof, prof.mupcl.elpres)[0]
@@ -471,10 +468,14 @@ def lhp(prof):
         term_b = (((shear_el - 25.)/5.) +\
                   ((grw_alpha_el + 5.)/20.) +\
                   ((srw_alpha_mid - 80.)/10.))
-        if term_b < 0:
-            term_b = 0
-
-        lhp = term_a * term_b + 5
+        
+        if term_a < 0 and term_b < 0:
+            lhp = 0
+        else:
+            lhp = term_a * term_b + 5
+        
+        if lhp < 0:
+            lhp = 0
 
     else:
         lhp = 0


### PR DESCRIPTION
Fix for issues #220 and #248. Modified the lhp calculation to set lhp to 0 if both term A and B are negative, and also set lhp to be 0 if it is still negative after adding 5, which is consistent with the following from Johnson and Sugden (2014):

> Additionally, if Term A and B are
both negative the LHP is set to zero to avoid
creating a positive value by multiplying two
negative terms. Finally, if values are still not
above zero after the previous addition term, all
negative values of the LHP are set to zero.